### PR TITLE
make the bot say things on tweet and incident commands

### DIFF
--- a/modules/bot.py
+++ b/modules/bot.py
@@ -73,12 +73,17 @@ def recognise_nick(bot, trigger):
         status = twit_api.PostUpdate(queuearg)
         print('Posted', queuearg)
         print('Status', status)
+        bot.say('https://twitter.com/{user}/status/{id}'.format(
+                    user=status.user.screen_name, id=status.id_str),
+                '#rust-infra')
     elif queueop == INCIDENT:
         assert queuearg in ['start', 'stop']
         if queuearg == 'start':
             twit_api.UpdateImage('error-incident.png')
+            bot.say('Incident started', '#rust-infra')
         elif queuearg == 'stop':
             twit_api.UpdateImage('error-bandage.png')
+            bot.say('Incident stopped', '#rust-infra')
 
 # Shouldn't need [ ] around the space, but it becomes optional if they're removed...
 @module.nickname_commands(r'incident[ ](?P<op>.*)')


### PR DESCRIPTION
This adds extra `bot.say` calls when executing `tweet` and `incident` commands so that the channel gets feedback when these commands execute successfully.

I'm not the strongest in Python so it's worth double-checking to see if i got the format call right. `>_>`